### PR TITLE
Feat/add sequences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "factory-girl-ts",
-  "version": "1.0.0",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "factory-girl-ts",
-      "version": "1.0.0",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "class-transformer": "^0.5.1"
@@ -35,7 +35,7 @@
         "vitest": "^0.30.1"
       },
       "engines": {
-        "node": ">= 19.8.1"
+        "node": ">= 18.16.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,45 @@ console.log(defaultUser);
 // Output: { name: 'John', email: 'some-email@mail.com', state: 'Some state', country: 'Some country' }
 ```
 
+#### Sequences
+
+Instead of providing a hardcoded value, we can tell `factory-girl-ts` to instead use a sequence.
+The first parameter is an unique id. It can be used for sharing sequence across multiple factories.
+The second parameter is a callback that give you an integer auto-incremented that you can use for construct your value.
+
+```ts
+import { User } from './models/user';
+import { FactoryGirl, SequelizeAdapter } from 'factory-girl-ts';
+
+// Step 1: Specify the adapter for your ORM.
+FactoryGirl.setAdapter(new SequelizeAdapter());
+
+// Step 2: Define your factory with default attributes for the model.
+const defaultAttributesFactory = () => ({
+  name: 'John',
+  email: FactoryGirl.sequence<string>(
+    'user.email',
+    (n: number) => `some-email-${n}@mail.com`,
+  ),
+  address: {
+    state: 'Some state',
+    country: 'Some country',
+  },
+});
+const userFactory = FactoryGirl.define(User, defaultAttributesFactory);
+
+// Step 3: Use the factory to create instances of the model.
+const defaultUser = userFactory.build();
+console.log(defaultUser);
+// Output: { name: 'John', email: 'some-email-1@mail.com', state: 'Some state', country: 'Some country' }
+const defaultUser2 = userFactory.build();
+console.log(defaultUser2);
+// Output: { name: 'John', email: 'some-email-2@mail.com', state: 'Some state', country: 'Some country' }
+const defaultUser3 = userFactory.build();
+console.log(defaultUser3);
+// Output: { name: 'John', email: 'some-email-3@mail.com', state: 'Some state', country: 'Some country' }
+```
+
 ### Overriding Default Properties
 
 You can override default properties when creating a model instance:

--- a/src/factory-girl.ts
+++ b/src/factory-girl.ts
@@ -10,7 +10,7 @@ export class FactoryGirl {
 
   static sequences = new Map<string, number>();
 
-  static sequence(id: string, callback: (seq: number) => number | string) {
+  static sequence<T>(id: string, callback: (seq: number) => T) {
     let seq = FactoryGirl.sequences.get(id);
     if (seq === undefined) seq = 0;
     seq++;

--- a/src/factory-girl.ts
+++ b/src/factory-girl.ts
@@ -8,6 +8,16 @@ import { InstanceOrInterface } from './types/instance-or-interface.type';
 export class FactoryGirl {
   static adapter: ModelAdapter<unknown, unknown> = new ObjectAdapter();
 
+  static sequences = new Map<string, number>();
+
+  static sequence(id: string, callback: (seq: number) => number | string) {
+    let seq = FactoryGirl.sequences.get(id);
+    if (seq === undefined) seq = 0;
+    seq++;
+    FactoryGirl.sequences.set(id, seq);
+    return callback(seq);
+  }
+
   static setAdapter(adapter: ModelAdapter<unknown, unknown>): void {
     this.adapter = adapter;
   }
@@ -26,5 +36,9 @@ export class FactoryGirl {
       model,
       this.adapter as ModelAdapter<ModelOrInterface, ReturnType>,
     );
+  }
+
+  static cleanUp(): void {
+    FactoryGirl.sequences.clear();
   }
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -44,7 +44,7 @@ export class Factory<
       await this.resolveAssociationsAsync(additionalParams);
 
     const finalAttributes = merge(defaultAttributesWithAssociations, override);
-    const built = this.build(finalAttributes, additionalParams);
+    const built = this.build(finalAttributes, additionalParams, false);
     const createdModel = await this.adapter.save(built, this.model);
     return await this.resolveHooks(createdModel);
   }
@@ -63,11 +63,16 @@ export class Factory<
   build(
     override?: PartialDeep<Attributes>,
     additionalParams?: Params,
+    shouldResolveAttributes = true,
   ): ReturnType {
-    const attributesWithAssociations =
-      this.resolveAssociations(additionalParams);
+    let mergedAttributes = override;
 
-    const mergedAttributes = merge(attributesWithAssociations, override);
+    if (shouldResolveAttributes) {
+      const attributesWithAssociations =
+        this.resolveAssociations(additionalParams);
+
+      mergedAttributes = merge(attributesWithAssociations, override);
+    }
 
     const finalResult = this.adapter.build(
       this.model,

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -164,6 +164,38 @@ describe('Factory', () => {
         email: 'user@company.com',
       });
     });
+
+    it('should build with sequence', () => {
+      // Arrange
+      const userFactory = FactoryGirl.define(plainObject<User>(), () => {
+        return {
+          name: 'John Doe',
+          email: FactoryGirl.sequence(
+            'user.email',
+            (n: number) => `test-${n}@mail.com`,
+          ),
+          address: {
+            street: 'Main Street',
+            number: 123,
+            city: 'New York',
+          },
+        };
+      });
+
+      // Act
+      const user = userFactory.build();
+
+      // Assert
+      expect(user).toEqual({
+        name: 'John Doe',
+        email: 'test-1@mail.com',
+        address: {
+          street: 'Main Street',
+          number: 123,
+          city: 'New York',
+        },
+      });
+    });
   });
 
   describe('buildMany', () => {
@@ -242,6 +274,33 @@ describe('Factory', () => {
           email: 'modified-email@mail.com',
         },
       ]);
+    });
+
+    it('should build many entities with sequences', () => {
+      // Arrange
+      const userFactory = FactoryGirl.define(plainObject<User>(), () => {
+        return {
+          name: 'John Doe',
+          email: FactoryGirl.sequence(
+            'users.email',
+            (n: number) => `test-${n}@mail.com`,
+          ),
+          address: {
+            street: 'Main Street',
+            number: 123,
+            city: 'New York',
+          },
+        };
+      });
+
+      // Act
+      const users = userFactory.buildMany(10);
+
+      // Assert
+      expect(users[0].email).toEqual('test-1@mail.com');
+      expect(users[5].email).toEqual('test-6@mail.com');
+      expect(users[9].email).toEqual('test-10@mail.com');
+      console.log(users);
     });
 
     describe('when using transient params', () => {

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -300,7 +300,6 @@ describe('Factory', () => {
       expect(users[0].email).toEqual('test-1@mail.com');
       expect(users[5].email).toEqual('test-6@mail.com');
       expect(users[9].email).toEqual('test-10@mail.com');
-      console.log(users);
     });
 
     describe('when using transient params', () => {


### PR DESCRIPTION
Hello @thiagomini,

We have implemented sequences into `FactoryGirl` class as static in order to keep (as possible) the same API of original `factory-girl` library.

During implementation, we faced some issues  in `Factory` class. We think there is a problem of architecture between the create, build, createMany and buildMany : the attributes factory `defaultAttributesFactory` (where we plug the sequence method) is called two times in create and build processes. We added a flag in order to avoid this twice call. 

What do you think ? 
