### PR TITLE
Fix create many with associated factories

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -54,9 +54,13 @@ export class Factory<
     partials?: PartialDeep<Attributes>[] | PartialDeep<Attributes>,
     additionalParams?: Params,
   ): Promise<ReturnType[]> {
-    const builtModels = this.buildMany(count, partials, additionalParams);
     return await Promise.all(
-      builtModels.map((model) => this.adapter.save(model, this.model)),
+      times(count).map((_partial, index) => {
+        return this.create(
+          Array.isArray(partials) ? partials?.[index] : partials,
+          additionalParams,
+        );
+      }),
     );
   }
 

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -523,6 +523,49 @@ describe('Factory', () => {
         },
       ]);
     });
+
+    it('should create many with associated factory', async () => {
+      // Arrange
+      const addressFactory = FactoryGirl.define(plainObject<Address>(), () => {
+        return {
+          street: 'Main Street',
+          number: FactoryGirl.sequence('number', (n) => n),
+          city: 'New York',
+        };
+      });
+      const userFactory = FactoryGirl.define(plainObject<User>(), () => {
+        return {
+          name: 'John Doe',
+          email: FactoryGirl.sequence('email', (n) => `test-${n}@mail.com`),
+          address: addressFactory.associate(),
+        };
+      });
+
+      // Act
+      const users = await userFactory.createMany(2);
+
+      // Assert
+      expect(users).toEqual([
+        {
+          name: 'John Doe',
+          email: 'test-1@mail.com',
+          address: {
+            street: 'Main Street',
+            number: 1,
+            city: 'New York',
+          },
+        },
+        {
+          name: 'John Doe',
+          email: 'test-2@mail.com',
+          address: {
+            street: 'Main Street',
+            number: 2,
+            city: 'New York',
+          },
+        },
+      ]);
+    });
   });
 
   describe('extend', () => {


### PR DESCRIPTION
Method `createMany` didn't call `create` method on associated factories. 
I simply refactor `createMany` for calling in loop the method `create`.
Also I added 2 tests.

What do you think ?