### PR TITLE
feat: allow specifying association's transient parameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -295,7 +295,7 @@ const addressFactory = FactoryGirl.define(Address, () => ({
 }));
 ```
 
-Lastly, the `associate()` method can also define a custom value for the associated model.
+Lastly, the `associate()` method can also define custom attributes for the associated model.
 
 ```ts
 const addressForCompanyUserFactory = FactoryGirl.define(Address, () => ({
@@ -307,6 +307,22 @@ const addressForCompanyUserFactory = FactoryGirl.define(Address, () => ({
   userId: userFactory.associate('id', {
     email: 'john@company.com', // This will create a user with the specified email.
   }),
+}));
+```
+
+```ts
+const addressForCompanyUserFactory = FactoryGirl.define(Address, () => ({
+  id: 1,
+  street: '123 Fake St.',
+  city: 'Springfield',
+  state: 'IL',
+  zip: '90210',
+  user: userFactory.associate(
+    {},
+    {
+      companyName: 'ACME', // This will create a user passing the "companyName" transient parameter. That parameter may be used by the user factory to alter the user's email for instance.
+    },
+  ),
 }));
 ```
 

--- a/src/association.ts
+++ b/src/association.ts
@@ -17,9 +17,10 @@ export class Association<
 > {
   constructor(
     private readonly factory: Factory<Model, Attributes, Params, ReturnType>,
-    private readonly adapter: ModelAdapter<any, ReturnType>,
+    private readonly adapter: ModelAdapter<Model, ReturnType>,
     private readonly additionalAttributes?: Override<Attributes, ReturnType>,
     private readonly key?: keyof ReturnType,
+    private readonly transientParams?: Params,
     private cachedBuiltModel?: ReturnType,
     private cachedCreatedModel?: ReturnType,
   ) {}
@@ -27,7 +28,10 @@ export class Association<
   async build(): Promise<ReturnType | ValueOf<ReturnType>> {
     this.cachedBuiltModel =
       this.cachedBuiltModel ??
-      (await this.factory.build(this.additionalAttributes));
+      (await this.factory.build(
+        this.additionalAttributes,
+        this.transientParams,
+      ));
 
     if (this.key) {
       return this.adapter.get(this.cachedBuiltModel, this.key);
@@ -39,7 +43,10 @@ export class Association<
   async create(): Promise<ReturnType | ValueOf<ReturnType>> {
     this.cachedCreatedModel =
       this.cachedCreatedModel ??
-      (await this.factory.create(this.additionalAttributes));
+      (await this.factory.create(
+        this.additionalAttributes,
+        this.transientParams,
+      ));
 
     if (this.key) {
       return this.adapter.get(this.cachedCreatedModel, this.key);

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -44,6 +44,10 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
   associate<O extends Override<Attributes, ReturnType>>(
     override: O,
   ): Association<Model, Attributes, Params, ReturnType>;
+  associate<O extends Override<Attributes, ReturnType>>(
+    override: O,
+    transientParams: Params,
+  ): Association<Model, Attributes, Params, ReturnType>;
   associate<
     K extends keyof ReturnType,
     O extends Override<Attributes, ReturnType>,
@@ -53,16 +57,17 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
     K extends keyof ReturnType,
     O extends Override<Attributes, ReturnType>,
   >(
-    key?: K | Override<Attributes, ReturnType>,
-    override?: O,
+    keyOrOverride?: K | Override<Attributes, ReturnType>,
+    overrideOrTransientParams?: O | Params,
   ): Association<Model, Attributes, Params, ReturnType> {
-    const isAssociationAttribute = isObject(key);
+    const isAssociationAttribute = isObject(keyOrOverride);
 
     return new Association<Model, Attributes, Params, ReturnType>(
       this,
       this.adapter,
-      isAssociationAttribute ? key : override,
-      isAssociationAttribute ? undefined : (key as K),
+      isAssociationAttribute ? keyOrOverride : (overrideOrTransientParams as O),
+      isAssociationAttribute ? undefined : (keyOrOverride as K),
+      overrideOrTransientParams as Params,
     );
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -41,13 +41,28 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
    * @returns An association object that can be used to build or create the associated model.
    */
   associate<K extends keyof ReturnType>(k?: K): Association<any, any, any, any>;
+  /**
+   * Creates an association with the current factory. You can optionally override the default attributes.
+   * @param override The attributes that override the default factory attributes.
+   */
   associate<O extends Override<Attributes, ReturnType>>(
     override: O,
   ): Association<Model, Attributes, Params, ReturnType>;
+  /**
+   * Creates an association with the current factory. You can optionally override the default attributes and
+   * transient parameters
+   * @param override The attributes that override the default factory attributes.
+   * @param transientParams The factory transient parameters.
+   */
   associate<O extends Override<Attributes, ReturnType>>(
     override: O,
     transientParams: Params,
   ): Association<Model, Attributes, Params, ReturnType>;
+  /**
+   * Creates an association with the current factory. You can optionally override the default attributes.
+   * @param key The key of this model to be returned when the association is resolved.
+   * @param override The attributes that override the default factory attributes.
+   */
   associate<
     K extends keyof ReturnType,
     O extends Override<Attributes, ReturnType>,


### PR DESCRIPTION
* Allows passing an association's transient parameters to modify the built model:

```ts
const userAssociation = companyUserFactory.associate(
  {},
  { companyName: 'ACME' },
);
```