### PR TITLE
feat: associate many

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -248,7 +248,7 @@ console.log(user2.get('name')); // Output: 'Foo'
 
 ### Working with Associations
 
-## Associate
+#### Associate
 
 `factory-girl-ts` provides an easy way to create associations between models using the `associate()` method. This method links a model to another by using an attribute from the associated model.
 
@@ -337,7 +337,7 @@ const addressFromFirstUser = await addressFactory.create({
 });
 ```
 
-## Associate Many
+#### Associate Many
 
 We can use the `associateMany(count, override, transientParams)` version to associate many instances of a model to another. This is useful when we have a `one-to-many` relationship between two models.
 

--- a/readme.md
+++ b/readme.md
@@ -248,6 +248,8 @@ console.log(user2.get('name')); // Output: 'Foo'
 
 ### Working with Associations
 
+## Associate
+
 `factory-girl-ts` provides an easy way to create associations between models using the `associate()` method. This method links a model to another by using an attribute from the associated model.
 
 Let's walk through an example to demonstrate how this works. We'll be using a `User` model and an `Address` model, where each user has one address.
@@ -333,6 +335,31 @@ Keep in mind `associate` only comes into play if no value is provided for the gi
 const addressFromFirstUser = await addressFactory.create({
   userId: 1,
 });
+```
+
+## Associate Many
+
+We can use the `associateMany(count, override, transientParams)` version to associate many instances of a model to another. This is useful when we have a `one-to-many` relationship between two models.
+
+Let's walk through an example to demonstrate how this works. We'll be using a `User` model and a `Profile` model, where each user has many profiles.
+
+```ts
+// Define the Profile Factory
+const profileFactory = FactoryGirl.define(Profile, () => ({
+  phone: '000000000',
+  imageUri: 'http://some-image-uri.com',
+}));
+
+// Define the User Factory, associating it with the Profile Factory.
+const userFactory = FactoryGirl.define(User, () => ({
+  id: 1,
+  name: 'John',
+  profiles: profileFactory.associateMany(2, { phone: '123456789' }),
+}));
+
+// Create a User instance with two associated Profiles.
+const user = await userFactory.create();
+console.log(user.profiles); // Output: [ { phone: '123456789', imageUri: 'http://some-image-uri.com' }, { phone: '123456789', imageUri: 'http://some-image-uri.com' } ]
 ```
 
 ### Extending Factories

--- a/src/association.ts
+++ b/src/association.ts
@@ -23,7 +23,21 @@ export class Association<
     private readonly transientParams?: Params,
     private cachedBuiltModel?: ReturnType,
     private cachedCreatedModel?: ReturnType,
+    private readonly count?: number,
   ) {}
+
+  public withCount(count: number): Association<Model, Attributes, Params> {
+    return new Association(
+      this.factory,
+      this.adapter,
+      this.additionalAttributes,
+      this.key,
+      this.transientParams,
+      this.cachedBuiltModel,
+      this.cachedCreatedModel,
+      count,
+    );
+  }
 
   async build(): Promise<ReturnType | ValueOf<ReturnType>> {
     this.cachedBuiltModel =
@@ -40,6 +54,14 @@ export class Association<
     return this.cachedBuiltModel;
   }
 
+  async buildMany(): Promise<ReturnType[] | ValueOf<ReturnType>[]> {
+    return this.factory.buildMany(
+      this.count ?? 1,
+      this.additionalAttributes,
+      this.transientParams,
+    );
+  }
+
   async create(): Promise<ReturnType | ValueOf<ReturnType>> {
     this.cachedCreatedModel =
       this.cachedCreatedModel ??
@@ -53,6 +75,22 @@ export class Association<
     }
 
     return this.cachedCreatedModel;
+  }
+
+  async createMany(): Promise<ReturnType[] | ValueOf<ReturnType>[]> {
+    return this.factory.createMany(
+      this.count ?? 1,
+      this.additionalAttributes,
+      this.transientParams,
+    );
+  }
+
+  async resolve(method: 'build' | 'create') {
+    if (method === 'build') {
+      return this.count ? this.buildMany() : this.build();
+    }
+
+    return this.count ? this.createMany() : this.create();
   }
 
   get(

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -89,11 +89,14 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
   associateMany<O extends Override<Attributes, ReturnType>>(
     count: number,
     override?: O,
+    transientParams?: Params,
   ): Association<any> {
     return new Association<Model, Attributes, Params, ReturnType>(
       this,
       this.adapter,
       override,
+      undefined,
+      transientParams,
     ).withCount(count);
   }
 

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -86,6 +86,13 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
     );
   }
 
+  /**
+   * Creates an association with the current factory that should create multiple models.
+   * @param count The number of models to create.
+   * @param override The attributes that override the default factory attributes.
+   * @param transientParams The factory transient parameters.
+   * @returns An association object that can be used to build or create the associated models.
+   */
   associateMany<O extends Override<Attributes, ReturnType>>(
     count: number,
     override?: O,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -86,6 +86,13 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
     );
   }
 
+  associateMany(count: number): Association<any> {
+    return new Association<Model, Attributes, Params, ReturnType>(
+      this,
+      this.adapter,
+    ).withCount(count);
+  }
+
   /**
    * Creates a model and saves it to the database. This is based on the default attributes and
    * can be overridden by passing in an object.
@@ -365,7 +372,7 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
     for (const prop in attributes as Dictionary) {
       const value = attributes[prop as keyof typeof attributes];
       if (isAssociation(value)) {
-        defaultWithAssociations[prop] = await value[associationType]();
+        defaultWithAssociations[prop] = await value.resolve(associationType);
       } else {
         defaultWithAssociations[prop] = value;
       }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -86,10 +86,14 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
     );
   }
 
-  associateMany(count: number): Association<any> {
+  associateMany<O extends Override<Attributes, ReturnType>>(
+    count: number,
+    override?: O,
+  ): Association<any> {
     return new Association<Model, Attributes, Params, ReturnType>(
       this,
       this.adapter,
+      override,
     ).withCount(count);
   }
 

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -790,24 +790,24 @@ describe('Factory', () => {
       ]);
     });
 
-    it.skip('should allow specifying association attributes', async () => {
+    it('should allow specifying association attributes', async () => {
       // Arrange
-      const userWithNewYorkCityFactory = userFactory.extend(() => ({
-        address: addressFactory.associate({
-          city: 'New York',
+      const userWithProfiles = userFactory.extend(() => ({
+        profiles: profileFactory.associateMany(2, {
+          imageUri: new URL('https://modified.com'),
         }),
       }));
       // Act
-      const newUser = await userWithNewYorkCityFactory.create();
+      const newUser = await userWithProfiles.create();
 
       // Assert
-      expect(newUser).toEqual({
-        ...buildUserAttributes(),
-        address: {
-          ...buildAddressAttributes(),
-          city: 'New York',
-        },
-      });
+      expect(newUser.profiles).toHaveLength(2);
+      expect(newUser.profiles![0].imageUri).toEqual(
+        new URL('https://modified.com'),
+      );
+      expect(newUser.profiles![1].imageUri).toEqual(
+        new URL('https://modified.com'),
+      );
     });
 
     it.skip('should allow specifying association attributes with key', async () => {


### PR DESCRIPTION
* Adds the `associateMany()` method to allow creating `one-to-many` or `many-to-many` relationships more easily