### PR TITLE
chore: remove additional parameters type

### DIFF
--- a/src/interfaces/default-attributes-factory.interface.ts
+++ b/src/interfaces/default-attributes-factory.interface.ts
@@ -4,15 +4,11 @@ export type AdditionalParams<Transient> = {
   transientParams?: Transient;
 };
 
-type DefaultAttributes<T> = (
+type DefaultAttributes<T> =
   | T
   | {
       [K in keyof T]?: T[K] | Association<T[K]>;
-    }
-) &
-  Partial<{
-    [key: string]: unknown;
-  }>;
+    };
 
 export type DefaultAttributesFactory<T, P> = (
   params: AdditionalParams<P>,


### PR DESCRIPTION
* Removes the additional parameters type - it was nullifying the type safety of the default parameters function.