### PR TITLE
feat: allows creation of factory with specific adapter

### DIFF
--- a/src/factory-girl.ts
+++ b/src/factory-girl.ts
@@ -56,11 +56,13 @@ export class FactoryGirl {
   >(
     model: ModelOrInterface,
     defaultAttributesFactory: DefaultAttributesFactory<Attributes, Parameters>,
+    adapter?: ModelAdapter<ModelOrInterface, ReturnType>,
   ): Factory<ModelOrInterface, Attributes, Parameters, ReturnType> {
     return new Factory<ModelOrInterface, Attributes, Parameters, ReturnType>(
       defaultAttributesFactory,
       model,
-      () => this.adapter as ModelAdapter<ModelOrInterface, ReturnType>,
+      () =>
+        adapter ?? (this.adapter as ModelAdapter<ModelOrInterface, ReturnType>),
     );
   }
 

--- a/src/factory-girl.ts
+++ b/src/factory-girl.ts
@@ -45,6 +45,7 @@ export class FactoryGirl {
    * to work properly.
    * @param model The model to define a factory for. It can be either a model class or an interface.
    * @param defaultAttributesFactory A function that returns the default attributes for the model.
+   * @param adapter (optional) The adapter to use to build and save the model.
    * @returns A factory for the model.
    */
   static define<

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -1,6 +1,6 @@
 import { FactoryGirl } from '@src/factory-girl';
 import { plainObject } from '@src/utils';
-import { ObjectAdapter, SequelizeAdapter } from '../lib';
+import { ModelAdapter, ObjectAdapter, SequelizeAdapter } from '../lib';
 import { Association, DeepPartialAttributes } from '../src';
 
 type User = {
@@ -649,19 +649,6 @@ describe('Factory', () => {
       });
     });
 
-    it('extends the factory with new attributes', async () => {
-      // Act
-      const companyEmailUserFactory = userFactory.extend(() => ({
-        anotherAttribute: 'value',
-      }));
-
-      // Assert
-      await expect(companyEmailUserFactory.build()).resolves.toEqual({
-        ...buildUserAttributes(),
-        anotherAttribute: 'value',
-      });
-    });
-
     it('extends the factory with async attributes', async () => {
       // Act
       const companyEmailUserFactory = userFactory.extend(async () => ({
@@ -879,6 +866,36 @@ describe('Factory', () => {
 
       // Assert
       expect(user).toBeTruthy();
+    });
+
+    test('creates factory with given adapter', async () => {
+      // Arrange
+      class TestableAdapter implements ModelAdapter<User, User> {
+        build(): User {
+          throw new Error('Method not implemented.');
+        }
+        save(): Promise<User> {
+          throw new Error('Method not implemented.');
+        }
+        get<K extends keyof User>(): User[K] {
+          throw new Error('Method not implemented.');
+        }
+      }
+
+      // Act
+      const userFactory = FactoryGirl.define(
+        plainObject<User>(),
+        () => {
+          return {
+            name: 'John Doe',
+            email: '',
+          };
+        },
+        new TestableAdapter(),
+      );
+
+      // Assert
+      expect(userFactory.adapter).toBeInstanceOf(TestableAdapter);
     });
   });
 


### PR DESCRIPTION
Often times in a large codebase we might need to create factories for different ORM's. For those scenarios, it's useful to be able to provide a custom adapter per factory. This PR allows the user to provide a custom adapter as the third argument to `FactoryGirl.define`:

```ts
const userFactory = FactoryGirl.define(
        plainObject<User>(),
        () => {
          return {
            name: 'John Doe',
            email: '',
          };
        },
        new CustomAdapter(),
);
```