### PR TITLE
fix: stop factory creating unused initial association

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -126,6 +126,7 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
   ): Promise<ReturnType> {
     const defaultAttributesWithAssociations = await this.resolveAssociations(
       'create',
+      override,
       additionalParams,
     );
 
@@ -190,6 +191,7 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
 
     const attributesWithAssociations = await this.resolveAssociations(
       'build',
+      override,
       additionalParams,
     );
 
@@ -409,11 +411,17 @@ export class Factory<Model, Attributes, Params = any, ReturnType = Model> {
 
   private async resolveAssociations(
     associationType: 'build' | 'create',
+    override?: Override<Attributes, ReturnType>,
     additionalParams?: Params,
   ): Promise<Attributes> {
-    const attributes = await this.defaultAttributesFactory({
+    const rawAttributes = await this.defaultAttributesFactory({
       transientParams: additionalParams,
     });
+    const attributes = mergeDeep<Override<Attributes, ReturnType>>(
+      rawAttributes as Override<Attributes, ReturnType>,
+      override,
+    );
+
     const defaultWithAssociations: Dictionary = {};
 
     for (const prop in attributes as Dictionary) {

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -495,7 +495,7 @@ describe('Factory', () => {
       // Arrange
       let createdAdditionalUser = false;
 
-      class TestableUserAdapter implements ModelAdapter<User, User> {
+      class TestableUserAdapter implements ObjectAdapter<User> {
         build(
           model: User,
           props: PartialDeep<


### PR DESCRIPTION
- Modifies the `resolveAssociations` function of the `Factory` class so that it first merges any provided overrides before looping through the attributes to resolve the associations  - which now avoids an unexpected entry in the database when the factory resolves a model with an association for the first time.
- Adds a new test case to ensure an additional model isn't saved by the adapter.